### PR TITLE
Stop making one query per custom type on startup

### DIFF
--- a/lib/sequel/extensions/pg_enum.rb
+++ b/lib/sequel/extensions/pg_enum.rb
@@ -149,12 +149,12 @@ module Sequel
             from(:pg_type).
             where(:oid=>enum_labels.keys).
             exclude(:typarray=>0).
-            select_map([:typname, Sequel.cast(:typarray, Integer).as(:v)])
+            select_map([:typname, Sequel.cast(:typarray, Integer).as(:v), Sequel.cast(:oid, Integer).as(:sv)])
 
           existing_oids = conversion_procs.keys
-          array_types.each do |name, oid|
+          array_types.each do |name, oid, scalar_oid|
             next if existing_oids.include?(oid)
-            register_array_type(name, :oid=>oid)
+            register_array_type(name, :oid=>oid, :scalar_oid=>scalar_oid)
           end
         end
 


### PR DESCRIPTION
On startup, the `pg_enum` extension was causing the `pg_array` extension to make a query for every custom type we have defined. This was to define a handler for arrays of that custom type. We don't need to do that as we already have all the data required, without having to go back to the database. If we pass in the scalar OID to `#register_array_type`, then it will behave as such.